### PR TITLE
Added manifest best practices: disable cleartext traffic

### DIFF
--- a/recipes/android/descriptions/ManifestbestpracticesdisableusesCleartextTraffic.html
+++ b/recipes/android/descriptions/ManifestbestpracticesdisableusesCleartextTraffic.html
@@ -1,0 +1,9 @@
+<h2>Abstract</h2>
+Out of best practices and Android coding guidelines, recommendations were abstracted which state that communication should be done over encrypted channels, such as HTTPS.
+<h2>Description</h2>
+Set the <code>android:usesCleartextTraffic</code> attribute in your manifest file to <code>false</code>.
+The default value for API level 27 or lower is <code>true</code> and API level 28 or higher is <code>false</code>.
+<h4>Correct code example:</h4>
+<pre>
+android:usesCleartextTraffic="false"
+</pre>

--- a/recipes/android/readme.md
+++ b/recipes/android/readme.md
@@ -12,4 +12,10 @@ Recipes created from security recommendations in the official Android documentat
          <li>Never allow mixed content</li>
       </ul>
     </li>
+    <li>Manifest best practices
+      <ul>
+         <li>Disable backups</li>
+         <li>Disable cleartext traffic</li>
+      </ul>
+    </li>
 </ul>

--- a/recipes/android/rules.sensei
+++ b/recipes/android/rules.sensei
@@ -133,6 +133,64 @@
         "ruleEnabled": true,
         "ruleScope": []
       }
+    },
+    {
+      "type": "f44c1b5b95c8157536e2ccdcaab231fdb753d59d",
+      "model": {
+        "expandNamespaces": false,
+        "errorMarkLocation": 1,
+        "errorMarkNode": 2,
+        "root": {
+          "id": 1,
+          "children": [],
+          "value": [],
+          "attributes": [
+            {
+              "id": 2,
+              "attribute": {
+                "optionalAttribute": false,
+                "disallowed": false,
+                "name": "android:usesCleartextTraffic",
+                "attributeNameType": 0,
+                "attributeType": 0,
+                "attributeValue": "true",
+                "attributeValueType": 0
+              }
+            }
+          ],
+          "tag": {
+            "disallowed": false,
+            "allowExtraAttributes": true,
+            "tagName": {
+              "name": "application",
+              "nameType": 0
+            }
+          }
+        },
+        "fixes": [
+          {
+            "fixDescription": "Change android:usesCleartextTraffic to false",
+            "fixes": [
+              {
+                "ft": "6480f2d7304d1261a223006b38d2df5dcac91bf1",
+                "t": {
+                  "removeValue": false,
+                  "newValue": "\"false\"",
+                  "nodeId": 2
+                }
+              }
+            ]
+          }
+        ],
+        "ruleName": "Manifest best practices: disable cleartext traffic",
+        "ruleID": "9059700d-74a1-4c5c-818f-5d27636cddc5",
+        "disableRuleIDs": [],
+        "ruleDescriptionFile": "ManifestbestpracticesdisableusesCleartextTraffic.html",
+        "ruleShortDescription": "When android:usesCleartextTraffic\u003d\"true\" is set the application will allow clear text traffic which could lead to data leakage",
+        "ruleErrorLevel": 3,
+        "ruleEnabled": true,
+        "ruleScope": []
+      }
     }
   ],
   "generators": []

--- a/recipes/android/rules.sensei
+++ b/recipes/android/rules.sensei
@@ -183,6 +183,7 @@
           }
         ],
         "ruleName": "Manifest best practices: disable cleartext traffic",
+        "category": "insufficient_transport_layer_protection:communication_over_cleartext_protocol_http",
         "ruleID": "9059700d-74a1-4c5c-818f-5d27636cddc5",
         "disableRuleIDs": [],
         "ruleDescriptionFile": "ManifestbestpracticesdisableusesCleartextTraffic.html",


### PR DESCRIPTION
When the `android:usesCleartextTraffic` is set to `true` the application will allow communication over cleartext protocols and potentially leaking data during transport or even allow an attacker to execute a Man-In-The-Middle attack.

source: [Android docs](https://developer.android.com/guide/topics/manifest/application-element#usesCleartextTraffic)