### PR TITLE
Do not expose collections

### DIFF
--- a/recipes/javagotchas/descriptions/DonotexposeinternalCollection.html
+++ b/recipes/javagotchas/descriptions/DonotexposeinternalCollection.html
@@ -1,0 +1,75 @@
+<h2>Abstract</h2>
+Class methods should return immutable copies of private member variables of type <code>java.util.Collection</code> to prevent external changes to the state of the object. This is the encapsulation principle of OOP.
+
+<h2>Description</h2>
+Returning an instance's private field of type <code>java.util.Collection</code> allows external manipulation of the
+    internal state of an instance of the class because the collections are mutable. This can lead to unexpected program
+    behavior when external classes manipulate data in the collection, especially in multi-threaded situations.
+
+Class methods should return immutable copies of private member variables of type <code>java.util.Collection</code>
+
+<table>
+    <tr>
+        <th>Before</th>
+        <th>After</th>
+    </tr>
+    <tr>
+        <td><pre>public class ListExample {
+    private List&#x3C;String&#x3E; myList;
+
+    public List&#x3C;String&#x3E; getMyList() {
+        return myList;
+    }
+}
+</pre>
+        </td>
+        <td><b>After applying Quickfix - Return an unmodifiable copy of the Collection</b>
+
+<pre>public class ListExample {
+    private List&#x3C;String&#x3E; myList;
+
+    public List&#x3C;String&#x3E; getMyList() {
+    <b>return (List&#x3C;String&#x3E;)java.util.Collections.unmodifiableCollection(myList);</b>
+    }
+}
+</pre>
+<b>After applying Quickfix - return an unmodifiable List</b>
+
+<pre>public class ListExample {
+    private List&#x3C;String&#x3E; myList;
+
+    public List&#x3C;String&#x3E; getMyList() {
+    <b>return java.util.Collections.unmodifiableList(myList);</b>
+    }
+}
+</pre>
+        </td>
+    </tr>
+    <tr>
+        <td><pre>public class SetExample {
+    private Set&#x3C;String&#x3E; mySet;
+
+    public Set&#x3C;String&#x3E; getSet() {
+        return mySet;
+    }
+}
+</pre>
+        </td>
+        <td><b>After applying Quickfix - return an unmodifiable Set</b>
+<pre>public class SetExample {
+    private Set&#x3C;String&#x3E; mySet;
+
+    public Set&#x3C;String&#x3E; getSet() {
+    <b>return java.util.Collections.unmodifiableSet(mySet);</b>
+    }
+}
+</pre>
+        </td>
+    </tr>
+</table>
+
+<h2>Resources</h2>
+<ul>
+    <li>Wikipedia definition of <a href="https://en.wikipedia.org/wiki/Encapsulation_(computer_programming)">Encapsulation (computer programming)</a></li>
+    <li>SEI CERT Oracle Coding Standard for Java <a href="https://wiki.sei.cmu.edu/confluence/display/java/OBJ05-J.+Do+not+return+references+to+private+mutable+class+members">OBJ05-J. Do not return references to private mutable class members</a></li>
+</ul>

--- a/recipes/javagotchas/markdown/DonotexposeinternalCollection.md
+++ b/recipes/javagotchas/markdown/DonotexposeinternalCollection.md
@@ -1,0 +1,64 @@
+# Do not leak internal state - Collections
+
+
+- returning an instance's private field of type Collection allows external manipulation of the internal state because the collections are mutable. This can lead to unexpected program behavior when external classes manipulate data in the collection, especially in multi-threaded situations.</li>
+
+## Before (List Example)
+
+```
+public class ListExample {
+    private List<String> myList;
+
+    public List<String> getMyList() {
+        return myList;
+    }
+}
+```
+
+## After applying Quickfix - Return an unmodifiable copy of the Collection
+
+```
+public class ListExample {
+    private List<String> myList;
+
+    public List<String> getMyList() {
+        return (List<String>)java.util.Collections.unmodifiableCollection(myList);
+    }
+}
+```
+
+## After applying Quickfix - return an unmodifiable List
+
+```
+public class ListExample {
+    private List<String> myList;
+
+    public List<String> getMyList() {
+        return java.util.Collections.unmodifiableList(myList);
+    }
+}
+```
+
+## Before (Set Example)
+
+```
+public class SetExample {
+    private Set<String> mySet;
+
+    public Set<String> getSet() {
+        return mySet;
+    }
+}
+```
+
+## After applying Quickfix - return an unmodifiable Set
+
+```
+public class SetExample {
+    private Set<String> mySet;
+
+    public Set<String> getSet() {
+        return java.util.Collections.unmodifiableSet(mySet);
+    }
+}
+```

--- a/recipes/javagotchas/rules.sensei
+++ b/recipes/javagotchas/rules.sensei
@@ -74,6 +74,22 @@
         "ruleEnabled": true,
         "ruleScope": []
       }
+    },
+    {
+      "type": "947034909c9b08d0b583170e594b0eb327933231",
+      "model": {
+        "yamlCode": "search:\n  reference:\n    allOf:\n    - in:\n        return:\n          type: \"{{{ type }}}\"\n          value:\n            reference:\n              name: \"{{{ name }}}\"\n    - in:\n        class:\n          member:\n            field:\n              allOf:\n              - type:\n                  reference:\n                    matches: \"java.util.Collection\u003c.*\u003e\"\n                  checkInheritance: true\n              - type: \"{{{ type }}}\"\n              modifier:\n                not:\n                  anyOf:\n                  - is: \"final\"\n                  - is: \"public\"\n              name: \"{{{ name }}}\"\n",
+        "mver": 6,
+        "yamlQuickFixCode": "availableFixes:\n- name: \"Return an unmodifiable copy of the Collection\"\n  actions:\n  - rewrite:\n      to: \"({{{ type }}})java.util.Collections.unmodifiableCollection({{{ . }}})\"\n- name: \"return an unmodifiable List\"\n  actions:\n  - rewrite:\n      to: \"java.util.Collections.unmodifiableList({{{ . }}})\"\n- name: \"Return an unmodifiable Set\"\n  actions:\n  - rewrite:\n      to: \"java.util.Collections.unmodifiableSet({{{ . }}})\"\n",
+        "ruleName": "Do not expose internal state - Collections",
+        "ruleID": "6020c2a8-e781-4f9b-b3f3-e606019614f9",
+        "disableRuleIDs": [],
+        "ruleDescriptionFile": "DonotexposeinternalCollection.html",
+        "ruleShortDescription": "Do not expose an internal Collection as it is mutable. return a copy or immutable view of the Collection",
+        "ruleErrorLevel": 1,
+        "ruleEnabled": true,
+        "ruleScope": []
+      }
     }
   ],
   "generators": []


### PR DESCRIPTION
exposing internal, private collections can create interesting bugs in multi-threaded environments and violates OOP encapsulation - wrapping the internal collection in an immutable class helps prevent issues and is cheaper than doing a deep copy

Co-authored-by: Mariana Mourão mmourao@securecodewarrior.com