### PR TITLE
Added Manifest best practices: explicit exported components

### DIFF
--- a/recipes/android/descriptions/Manifestbestpracticesdisableexportofandroidcomponents.html
+++ b/recipes/android/descriptions/Manifestbestpracticesdisableexportofandroidcomponents.html
@@ -1,0 +1,14 @@
+<h2>Description</h2>
+<p>When an android component has the attribute <code>android:exported="true"</code>, components of other applications will be able to call the exported component. This could allow an adversary to gain access to sensitive information, trick a user into thinking they're still using the malicious application, or even modify the internal state of the application.</p> 
+
+<p>When defining an intent-filter, android components are exported by default. When other applications shouldn't call your component, it's considered good practice to explicitly set the exported value to false. </p>
+
+<h4>Before:</h4>
+<pre>
+android:exported="true"
+</pre>
+
+<h4>After:</h4>
+<pre>
+android:exported="false"
+</pre>

--- a/recipes/android/readme.md
+++ b/recipes/android/readme.md
@@ -16,6 +16,7 @@ Recipes created from security recommendations in the official Android documentat
       <ul>
          <li>Disable backups</li>
          <li>Disable cleartext traffic</li>
+         <li>Disable explicit exported components</li>
       </ul>
     </li>
 </ul>

--- a/recipes/android/rules.sensei
+++ b/recipes/android/rules.sensei
@@ -269,6 +269,66 @@
         "ruleEnabled": true,
         "ruleScope": []
       }
+    },
+    {
+      "type": "f44c1b5b95c8157536e2ccdcaab231fdb753d59d",
+      "model": {
+        "expandNamespaces": false,
+        "errorMarkLocation": 1,
+        "errorMarkNode": 3,
+        "root": {
+          "id": 1,
+          "children": [],
+          "value": [],
+          "attributes": [
+            {
+              "id": 3,
+              "attribute": {
+                "optionalAttribute": false,
+                "disallowed": false,
+                "name": "android:exported",
+                "attributeNameType": 0,
+                "attributeType": 0,
+                "attributeValue": "true",
+                "attributeValueType": 0
+              }
+            }
+          ],
+          "tag": {
+            "disallowed": false,
+            "allowExtraAttributes": true,
+            "tagName": {
+              "name": ".*",
+              "nameType": 1
+            }
+          }
+        },
+        "fixes": [
+          {
+            "fixDescription": "Change android:exported to false",
+            "fixes": [
+              {
+                "ft": "6480f2d7304d1261a223006b38d2df5dcac91bf1",
+                "t": {
+                  "removeValue": false,
+                  "newValue": "\"false\"",
+                  "nodeId": 3
+                }
+              }
+            ]
+          }
+        ],
+        "ruleName": "Manifest best practices: explicit exported components",
+        "category": "improper_platform_usage:incorrect_activity_configuration",
+        "cweCategory": 926,
+        "ruleID": "9c87e3b9-7b4a-412a-a8ab-11e7b708be50",
+        "disableRuleIDs": [],
+        "ruleDescriptionFile": "Manifestbestpracticesdisableexportofandroidcomponents.html",
+        "ruleShortDescription": "When android:exported is set to true any application will be able to call this component.",
+        "ruleErrorLevel": 1,
+        "ruleEnabled": true,
+        "ruleScope": []
+      }
     }
   ],
   "generators": []


### PR DESCRIPTION
This recipe checks whether a developer has explicitly set the exported value to true.

Sources:
- [CWE-926](https://cwe.mitre.org/data/definitions/926.html)
- [android service docs](https://developer.android.com/guide/topics/manifest/service-element#exported)
- [android receiver docs](https://developer.android.com/guide/topics/manifest/receiver-element#exported)
- [android provider docs](https://developer.android.com/guide/topics/manifest/provider-element#exported)
- [android activity docs](https://developer.android.com/guide/topics/manifest/activity-element#exported)