### PR TITLE
Added recipe: explicitly disable backups

### DIFF
--- a/recipes/android/descriptions/AndroidManifestbestpracticesDisableBackups.html
+++ b/recipes/android/descriptions/AndroidManifestbestpracticesDisableBackups.html
@@ -1,9 +1,29 @@
 <h2>Abstract</h2>
-Out of best practices and android coding guidelines, recommendations were abstracted which state that <code>android:allowBackup</code> should be set to <code>false</code> in the Android Manifest.
+<p>Out of best practices and android coding guidelines, recommendations were abstracted which state that <code>android:allowBackup</code> should be set to <code>false</code> in the Android Manifest.</p>
 <h2>Description</h2>
-Disabling the <code>android:allowBackup</code> attribute will ensure that no backups are created. Since using this functionality is insecure.  when the Android system is allowed to create backups, copies are made of the application and its data. These backups can be studied by attackers or tampered with before using it to recover from the backup.
-<h4>Correct code example:</h4>
-<pre>
-&lt;application
-&nbsp;&nbsp;&nbsp;<b>android:allowBackup="false"</b> /&gt;
-</pre>
+<p>Disabling the <code>android:allowBackup</code> attribute will ensure that no backups are created. Since using this functionality is insecure.  when the Android system is allowed to create backups, copies are made of the application and its data. These backups can be studied by attackers or tampered with before using it to recover from the backup.</p>
+<p>The default value of <code>android:allowBackup</code> is <code>true</code>.</p>
+<table>
+    <tr>
+      <th>Before</th>
+      <th>After</th>
+    </tr>
+    <tr>
+      <td>
+        <pre>
+            &lt;application
+            android:allowBackup="<b>true<b>" /&gt;
+        </pre>
+      </td>
+      <td>
+        <pre>
+            &lt;application
+            android:allowBackup="<b>false</b>" /&gt;
+      </pre>
+      </td>
+    </tr> 
+</table>
+<h4>Resources</h4>
+<ul>
+  <li><a href="https://developer.android.com/guide/topics/manifest/application-element#allowbackup">Android Documentation</a></li>
+</ul>

--- a/recipes/android/readme.md
+++ b/recipes/android/readme.md
@@ -15,6 +15,7 @@ Recipes created from security recommendations in the official Android documentat
     <li>Manifest best practices
       <ul>
          <li>Disable backups</li>
+         <li>Explicitly disable backups</li>
          <li>Disable cleartext traffic</li>
          <li>Explicitly disable cleartext traffic</li>
          <li>Disable explicit exported components</li>

--- a/recipes/android/rules.sensei
+++ b/recipes/android/rules.sensei
@@ -10,6 +10,67 @@
   },
   "rules": [
     {
+      "type": "f44c1b5b95c8157536e2ccdcaab231fdb753d59d",
+      "model": {
+        "expandNamespaces": false,
+        "errorMarkLocation": 1,
+        "errorMarkNode": 1,
+        "root": {
+          "id": 1,
+          "children": [],
+          "value": [],
+          "attributes": [
+            {
+              "id": 2,
+              "attribute": {
+                "optionalAttribute": false,
+                "disallowed": true,
+                "name": "android:allowBackup",
+                "attributeNameType": 0,
+                "attributeType": 1,
+                "attributeValue": "",
+                "attributeValueType": 2
+              }
+            }
+          ],
+          "tag": {
+            "disallowed": false,
+            "allowExtraAttributes": true,
+            "tagName": {
+              "name": "application",
+              "nameType": 0
+            }
+          }
+        },
+        "fixes": [
+          {
+            "fixDescription": "Insert attribute android:allowBackup",
+            "fixes": [
+              {
+                "ft": "88114b12741535974bf60f48bda3756f95fb564d",
+                "t": {
+                  "value": "android:allowBackup\u003d\"false\"",
+                  "nodeId": 1
+                }
+              }
+            ]
+          }
+        ],
+        "commonFixes": [],
+        "ruleName": "Android Manifest best practices: explicitly Disable Backups",
+        "category": "code_tampering:backups_enabled",
+        "cweCategory": 530,
+        "ruleID": "a44c0e04-ea4a-4081-8189-bafd821bcd3f",
+        "disableRuleIDs": [],
+        "ruleDescriptionFile": "AndroidManifestbestpracticesDisableBackups.html",
+        "ruleShortDescription": "The default value of allowBackup is true, this could lead to undesired manipulation.",
+        "ruleErrorLevel": 2,
+        "ruleEnabled": true,
+        "comment": "",
+        "ruleScope": []
+      }
+    },
+    {
       "type": "947034909c9b08d0b583170e594b0eb327933231",
       "model": {
         "yamlCode": "search:\n  instanceCreation:\n    not:\n      followedBy:\n        methodcall:\n          followedBy:\n            methodcall:\n              name: \"setMixedContentMode\"\n          name: \"getSettings\"\n    type: \"android.webkit.WebView\"\n",
@@ -182,6 +243,7 @@
             ]
           }
         ],
+        "commonFixes": [],
         "ruleName": "Manifest best practices: disable cleartext traffic",
         "category": "insufficient_transport_layer_protection:communication_over_cleartext_protocol_http",
         "cweCategory": 319,
@@ -213,8 +275,8 @@
                 "name": "android:allowBackup",
                 "attributeNameType": 0,
                 "attributeType": 0,
-                "attributeValue": "true",
-                "attributeValueType": 0
+                "attributeValue": "true|^$",
+                "attributeValueType": 1
               }
             }
           ],
@@ -242,12 +304,14 @@
             ]
           }
         ],
+        "commonFixes": [],
         "ruleName": "Android Manifest best practices: Disable Backups",
         "category": "code_tampering:backups_enabled",
+        "cweCategory": 530,
         "ruleID": "5c354f81-611d-415d-9ae8-905bb9a7579d",
         "disableRuleIDs": [],
         "ruleDescriptionFile": "AndroidManifestbestpracticesDisableBackups.html",
-        "ruleShortDescription": "Enabling backups could lead to potential data leakage",
+        "ruleShortDescription": "Enabling backups could lead to undesired manipulation.",
         "ruleErrorLevel": 2,
         "ruleEnabled": true,
         "comment": "",
@@ -319,6 +383,7 @@
             ]
           }
         ],
+        "commonFixes": [],
         "ruleName": "Manifest best practices: explicit exported components",
         "category": "improper_platform_usage:incorrect_activity_configuration",
         "cweCategory": 926,
@@ -366,7 +431,7 @@
         },
         "fixes": [
           {
-            "fixDescription": "Set android:usesCleartextTraffic to false",
+            "fixDescription": "Insert attribute android:usesCleartextTraffic",
             "fixes": [
               {
                 "ft": "88114b12741535974bf60f48bda3756f95fb564d",
@@ -378,6 +443,7 @@
             ]
           }
         ],
+        "commonFixes": [],
         "ruleName": "Manifest best pracices: explicitly disable cleartext traffic",
         "category": "insufficient_transport_layer_protection:communication_over_cleartext_protocol_http",
         "cweCategory": 319,


### PR DESCRIPTION
Added a recipe that checks if android:allowBackup is not present and set it to false.

The default value of android:allowBackup is true.

Co-Authored-by: Nick Van Haver <nhaver@securecodewarrior.com>