### PR TITLE
SEN-1865 prevent sqli by parameterising

### DIFF
--- a/recipes/spring/spring-data/descriptions/Injection-SQLInjectioninJPAEntityManagercreateNativeQuery.html
+++ b/recipes/spring/spring-data/descriptions/Injection-SQLInjectioninJPAEntityManagercreateNativeQuery.html
@@ -1,0 +1,15 @@
+<h2>Description</h2>
+Dynamically creating queries by means of concatenating (untrusted) user input puts the application at risk of SQL injection. An attacker could insert malicious input to obtain or modify data.
+
+Use parameterized queries to prevent SQL injection.
+
+<b>Before</b>
+<pre>entityManager.createNativeQuery("Select * from Books where author = " + author)
+.getResultList();</pre>
+<b>After</b>
+<pre>entityManager.createNativeQuery("Select * from Books where author = <b>?</b>")
+<b>.setParameter(1, author)</b>
+.getResultList();</pre>
+
+<h2>Resources</h2>
+<a href="https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html">Owasp cheat sheet on SQLi</a>

--- a/recipes/spring/spring-data/descriptions/Injection-SQLInjectioninJPAEntityManagercreateQuery.html
+++ b/recipes/spring/spring-data/descriptions/Injection-SQLInjectioninJPAEntityManagercreateQuery.html
@@ -1,0 +1,14 @@
+<h2>Description</h2>
+Dynamically creating queries by means of concatenating (untrusted) user input puts the application at risk of SQL injection. An attacker could insert malicious input to obtain or modify data.
+
+Use parameterized queries to prevent SQL injection.
+
+<b>Before</b>
+<pre>entityManager.createQuery("Select b from Books b where b.author like " + author).getResultList();</pre>
+<b>After</b>
+<pre>entityManager.createQuery("Select b from Books b where b.author like <b>:author</b>")
+<b>.setParameter("author", author)</b>
+.getResultList();</pre>
+
+<h2>Resources</h2>
+<a href="https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html">Owasp cheat sheet on SQLi</a>

--- a/recipes/spring/spring-data/readme.md
+++ b/recipes/spring/spring-data/readme.md
@@ -1,0 +1,9 @@
+## Spring Data Cookbook
+A cookbook that simplifies Spring Data development. It aims to automate common routines
+performed by developers, preventing them to repeat themselves or introduce known issues.
+
+It covers the following protections:
+<ul>
+<li>Injection - SQL Injection in JPA: EntityManager#createNativeQuery</li>
+<li>Injection - SQL Injection in JPA: EntityManager#createQuery</li>
+</ul>

--- a/recipes/spring/spring-data/rules.sensei
+++ b/recipes/spring/spring-data/rules.sensei
@@ -1,0 +1,48 @@
+{
+  "header": {
+    "name": "Custom cookbook",
+    "description": "cookbook for internal use within our company",
+    "company": "SCW",
+    "appsecmail": "appsecteam@senseifinancial.com",
+    "rulepack_id": "768d4ceb-2808-4346-8575-70580891b0b3",
+    "rulePackVersion": "0.1.0",
+    "enabled": true
+  },
+  "rules": [
+    {
+      "type": "947034909c9b08d0b583170e594b0eb327933231",
+      "model": {
+        "yamlCode": "search:\n  methodcall:\n    args:\n      1:\n        containsUntrustedInput: true\n        trustedSources:\n        - methodcall:\n            name: \"format\"\n            type: \"java.lang.String\"\n        type: \"java.lang.String\"\n    name:\n      matches: \"createNativeQuery\"\n    type: \"javax.persistence.EntityManager\"\n",
+        "mver": 6,
+        "yamlQuickFixCode": "availableFixes:\n- name: \"Use parameterized queries\"\n  actions:\n  - parameterize:\n      placeholderFormat: \"?\"\n      extractUntrustedInput:\n        methodsOnObject:\n          methods:\n          - methodName: \"setParameter\"\n            args:\n              1: \"{{{ index }}}\"\n              2: \"{{{.}}}\"\n          target:\n            returnValue:\n              useMethodChaining: true\n",
+        "ruleName": "Injection - SQL Injection in JPA: EntityManager#createNativeQuery",
+        "category": "injection:sql",
+        "ruleID": "6e367e8f-c966-4f78-92db-53780dae8a76",
+        "disableRuleIDs": [],
+        "ruleDescriptionFile": "Injection-SQLInjectioninJPAEntityManagercreateNativeQuery.html",
+        "ruleShortDescription": "Avoid SQLi by using parameterized queries, instead of string concatenation with untrusted input",
+        "ruleErrorLevel": 2,
+        "ruleEnabled": true,
+        "ruleScope": []
+      }
+    },
+    {
+      "type": "947034909c9b08d0b583170e594b0eb327933231",
+      "model": {
+        "yamlCode": "search:\n  methodcall:\n    args:\n      1:\n        containsUntrustedInput: true\n        trustedSources:\n        - methodcall:\n            name: \"format\"\n            type: \"java.lang.String\"\n        type: \"java.lang.String\"\n    name:\n      matches: \"createQuery\"\n    type: \"javax.persistence.EntityManager\"\n",
+        "mver": 6,
+        "yamlQuickFixCode": "availableFixes:\n  - name: \"Use parameterized queries\"\n    actions:\n      - parameterize:\n          placeholderFormat: \":{{{name}}}\"\n          extractUntrustedInput:\n            methodsOnObject:\n              methods:\n                - methodName: \"setParameter\"\n                  args:\n                    \"1\": \"\\\"{{{ name }}}\\\"\"\n                    \"2\": \"{{{ . }}}\"\n              target:\n                returnValue:\n                  useMethodChaining: true",
+        "ruleName": "Injection - SQL Injection in JPA: EntityManager#createQuery",
+        "category": "injection:sql",
+        "ruleID": "b1834002-1ae5-4f5c-99ed-bc4346ff892b",
+        "disableRuleIDs": [],
+        "ruleDescriptionFile": "Injection-SQLInjectioninJPAEntityManagercreateQuery.html",
+        "ruleShortDescription": "Avoid SQLi by using parameterized queries, instead of string concatenation with untrusted input",
+        "ruleErrorLevel": 2,
+        "ruleEnabled": true,
+        "ruleScope": []
+      }
+    }
+  ],
+  "generators": []
+}


### PR DESCRIPTION
Two recipes, one for [createQuery()](https://securecodewarrior.atlassian.net/wiki/spaces/CP/pages/1565065253/SQLi+-+createQuery) and one for [createNativeQuery()](https://securecodewarrior.atlassian.net/wiki/spaces/CP/pages/1564966921/SQLi+-+createNativeQuery)

The reason the searchers include 'trustedsources' is to prevent them from triggering on String.format, which would result in an unwanted quickfix. [SEN-1866](https://securecodewarrior.atlassian.net/browse/SEN-1866)
