### PR TITLE
SEN-2025: Recipes for default insecure settings of cookies

### DIFF
--- a/recipes/apache/descriptions/SessionconfigurationCookiesConfigureSecureflag.html
+++ b/recipes/apache/descriptions/SessionconfigurationCookiesConfigureSecureflag.html
@@ -1,0 +1,7 @@
+
+
+Ensure the cookie is only sent over HTTPS by setting the <code>setSecure()</code> flag to true. Otherwise, when using the default setting, the cookie will be sent over an unencrypted HTTP connection and the session ID could be disclosed via a Man-in-the-Middle attack.
+
+<table><tr><td><font color="gray">Before:</font></td><td><font color="#AA0000">SimpleCookie simpleCookie = new SimpleCookie();</font></td></tr><tr><td><font color="gray">After:</font></td><td>SimpleCookie simpleCookie = new SimpleCookie();
+        simpleCookie.setSecure(true);</td></tr></table>
+<h3>Resources</h3><ul><li><a href="https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#secure-attribute">OWASP - Session Management Cheat Sheet - Secure</a></li></ul>

--- a/recipes/apache/readme.md
+++ b/recipes/apache/readme.md
@@ -6,4 +6,5 @@ It covers the following protections:
 <ul>
 <li>Session configuration: Cookies: Set HttpOnly flag to true</li>
 <li>Session configuration: Cookies: Set Secure flag to true</li>
+<li>Session configuration: Cookies: Configure Secure flag</li>
 </ul>

--- a/recipes/apache/rules.sensei
+++ b/recipes/apache/rules.sensei
@@ -43,6 +43,23 @@
         "ruleScope": [],
         "ruleEnabled": true
       }
+    },
+    {
+      "type": "947034909c9b08d0b583170e594b0eb327933231",
+      "model": {
+        "yamlCode": "search:\n  instanceCreation:\n    not:\n      with:\n        followedBy:\n          methodcall:\n            name: \"setSecure\"\n    type: \"org.apache.shiro.web.servlet.SimpleCookie\"\n",
+        "mver": 8,
+        "yamlQuickFixCode": "availableFixes:\n  - name: \"Set the Secure flag to true\"\n    actions:\n      - addMethodCall:\n          name: \"setSecure\"\n          arguments:\n            - \"true\"\n          position: \"first-available-spot\"\n",
+        "ruleName": "Session configuration: Cookies: Configure Secure flag",
+        "category": "improper_session_handling:improper_flags_in_cookie_headers",
+        "ruleID": "2dbe8479-b2c7-4a18-86ef-a26cc1aa395e",
+        "disableRuleIDs": [],
+        "ruleDescriptionFile": "SessionconfigurationCookiesConfigureSecureflag.html",
+        "ruleShortDescription": "Prevent a cookie being sent over unencrypted HTTP by setting the Secure flag to true ",
+        "ruleErrorLevel": 2,
+        "ruleScope": [],
+        "ruleEnabled": true
+      }
     }
   ],
   "generators": []

--- a/recipes/bad-practices/descriptions/SessionconfigurationCookieSetHttpOnlytotrue.html
+++ b/recipes/bad-practices/descriptions/SessionconfigurationCookieSetHttpOnlytotrue.html
@@ -1,6 +1,6 @@
 
 
-Session cookies are frequently the target of Cross-Site Scripting (XSS) attacks. By setting the <code>setHttpOnly()</code> flag to true (which is also the default setting), the cookie cannot be accessed by client-side scripts.
+Session cookies are frequently the target of Cross-Site Scripting (XSS) attacks. By setting the <code>setHttpOnly()</code> flag to true, the cookie cannot be accessed by client-side scripts.
 
 <table><tr><td><font color="gray">Before:</font></td><td><font color="#AA0000">cookie.setHttpOnly(false);</font></td></tr><tr><td><font color="gray">After:</font></td><td>cookie.setHttpOnly(true);</td></tr></table>
 <h3>Resources</h3><ul><li><a href="https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#httponly-attribute">OWASP - Session Management Cheat Sheet - HttpOnly</a></li></ul>

--- a/recipes/bad-practices/descriptions/SessionconfigurationCookiesConfigureHttpOnlyflag.html
+++ b/recipes/bad-practices/descriptions/SessionconfigurationCookiesConfigureHttpOnlyflag.html
@@ -1,0 +1,7 @@
+
+
+Session cookies are frequently the target of Cross-Site Scripting (XSS) attacks. The default setting of the HttpOnly flag is false, which is insecure. By setting the <code>setHttpOnly()</code> to true, the cookie cannot be accessed by client-side scripts.
+
+<table><tr><td><font color="gray">Before:</font></td><td><font color="#AA0000">Cookie cookie = new Cookie("name", "value");</font></td></tr><tr><td><font color="gray">After:</font></td><td>Cookie cookie = new Cookie("name", "value");
+        cookie.setHttpOnly(true);</td></tr></table>
+<h3>Resources</h3><ul><li><a href="https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#httponly-attribute">OWASP - Session Management Cheat Sheet - HttpOnly</a></li></ul>

--- a/recipes/bad-practices/descriptions/SessionconfigurationCookiesConfigureSecureflag.html
+++ b/recipes/bad-practices/descriptions/SessionconfigurationCookiesConfigureSecureflag.html
@@ -1,0 +1,7 @@
+
+
+Ensure the cookie is only sent over HTTPS by setting the <code>setSecure()</code> flag to true. Otherwise, when using the default setting, the cookie will be sent over an unencrypted HTTP connection and the session ID could be disclosed via a Man-in-the-Middle attack.
+
+<table><tr><td><font color="gray">Before:</font></td><td><font color="#AA0000">Cookie cookie = new Cookie("name", "value");</font></td></tr><tr><td><font color="gray">After:</font></td><td>Cookie cookie = new Cookie("name", "value");
+        cookie.setSecure(true);</td></tr></table>
+<h3>Resources</h3><ul><li><a href="https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#secure-attribute">OWASP - Session Management Cheat Sheet - Secure</a></li></ul>

--- a/recipes/bad-practices/readme.md
+++ b/recipes/bad-practices/readme.md
@@ -6,4 +6,6 @@ Examples of Java bad practices
 <li>Use java.security.SecureRandom instead of java.util.Random</li>
 <li>Session configuration: Cookies: Set HttpOnly flag to true</li>
 <li>Session configuration: Cookies: Set Secure flag to true</li>
+<li>Session configuration: Cookies: Configure HttpOnly flag</li>
+<li>Session configuration: Cookies: Configure Secure flag</li>
 </ul>

--- a/recipes/bad-practices/rules.sensei
+++ b/recipes/bad-practices/rules.sensei
@@ -12,6 +12,23 @@
     {
       "type": "947034909c9b08d0b583170e594b0eb327933231",
       "model": {
+        "yamlCode": "search:\n  instanceCreation:\n    not:\n      with:\n        followedBy:\n          methodcall:\n            name: \"setHttpOnly\"\n    type: \"javax.servlet.http.Cookie\"\nscopes:\n  library:\n    minVersion: \"3.0\"\n    name:\n      contains: \"javax.servlet-api\"\n",
+        "mver": 8,
+        "yamlQuickFixCode": "availableFixes:\n- name: \"Set the HttpOnly flag to true\"\n  actions:\n  - addMethodCall:\n      name: \"setHttpOnly\"\n      arguments:\n      - \"true\"\n      position: \"first-available-spot\"\n",
+        "ruleName": "Session configuration: Cookie: Configure HttpOnly flag",
+        "category": "improper_session_handling:improper_flags_in_cookie_headers",
+        "ruleID": "d9d42f72-8599-44c5-85dc-ae4b118e3a6a",
+        "disableRuleIDs": [],
+        "ruleDescriptionFile": "SessionconfigurationCookiesConfigureHttpOnlyflag.html",
+        "ruleShortDescription": "Prevent client-side scripts from accessing the cookie by setting the HttpOnly flag to true",
+        "ruleErrorLevel": 2,
+        "ruleScope": [],
+        "ruleEnabled": true
+      }
+    },
+    {
+      "type": "947034909c9b08d0b583170e594b0eb327933231",
+      "model": {
         "yamlCode": "search:\n  instanceCreation:\n    type:\n      reference: java.util.Random\n      checkInheritance: false\n",
         "mver": 8,
         "yamlQuickFixCode": "availableFixes:\n- name: \"Use SecureRandom instead\"\n  actions:\n  - rewrite:\n      to: \"new java.security.SecureRandom()\"\n  - modifyAssignedVariable:\n      type: \"java.security.SecureRandom\"\n",
@@ -80,10 +97,10 @@
     {
       "type": "947034909c9b08d0b583170e594b0eb327933231",
       "model": {
-        "yamlCode": "search:\n  instanceCreation:\n    not:\n      with:\n        followedBy:\n          methodcall:\n            name: \"setHttpOnly\"\n    anyOf:\n      - type: \"javax.servlet.http.Cookie\"\n      - type: \"java.net.HttpCookie\"\n",
+        "yamlCode": "search:\n  instanceCreation:\n    not:\n      with:\n        followedBy:\n          methodcall:\n            name: \"setHttpOnly\"\n    type: \"java.net.HttpCookie\"\n",
         "mver": 8,
-        "yamlQuickFixCode": "availableFixes:\n- name: \"Set the HttpOnly flag to true\"\n  actions:\n  - addMethodCall:\n      name: \"setHttpOnly\"\n      arguments:\n      - \"true\"\n      position: \"first-available-spot\"\n",
-        "ruleName": "Session configuration: Cookies: Configure HttpOnly flag",
+        "yamlQuickFixCode": "availableFixes:\n  - name: \"Set the HttpOnly flag to true\"\n    actions:\n      - addMethodCall:\n          name: \"setHttpOnly\"\n          arguments:\n            - \"true\"\n          position: \"first-available-spot\"\n",
+        "ruleName": "Session configuration: HttpCookie: Configure HttpOnly flag",
         "category": "improper_session_handling:improper_flags_in_cookie_headers",
         "ruleID": "d34a476b-dede-44c7-8484-03ec48cc8661",
         "disableRuleIDs": [],

--- a/recipes/bad-practices/rules.sensei
+++ b/recipes/bad-practices/rules.sensei
@@ -59,6 +59,40 @@
         "ruleScope": [],
         "ruleEnabled": true
       }
+    },
+    {
+      "type": "947034909c9b08d0b583170e594b0eb327933231",
+      "model": {
+        "yamlCode": "search:\n  instanceCreation:\n    not:\n      followedBy:\n        methodcall:\n          name: \"setSecure\"\n    anyOf:\n    - type: \"javax.servlet.http.Cookie\"\n    - type: \"java.net.HttpCookie\"\n",
+        "mver": 8,
+        "yamlQuickFixCode": "availableFixes:\n- name: \"Set the Secure flag to true\"\n  actions:\n  - addMethodCall:\n      name: \"setSecure\"\n      arguments:\n      - \"true\"\n      position: \"first-available-spot\"\n",
+        "ruleName": "Session configuration: Cookies: Configure Secure flag",
+        "category": "improper_session_handling:improper_flags_in_cookie_headers",
+        "ruleID": "07dcb90d-039f-4546-8e25-aaeb59862ed3",
+        "disableRuleIDs": [],
+        "ruleDescriptionFile": "SessionconfigurationCookiesConfigureSecureflag.html",
+        "ruleShortDescription": "Prevent a cookie being sent over unencrypted HTTP by setting the Secure flag to true",
+        "ruleErrorLevel": 2,
+        "ruleScope": [],
+        "ruleEnabled": true
+      }
+    },
+    {
+      "type": "947034909c9b08d0b583170e594b0eb327933231",
+      "model": {
+        "yamlCode": "search:\n  instanceCreation:\n    not:\n      with:\n        followedBy:\n          methodcall:\n            name: \"setHttpOnly\"\n    anyOf:\n      - type: \"javax.servlet.http.Cookie\"\n      - type: \"java.net.HttpCookie\"\n",
+        "mver": 8,
+        "yamlQuickFixCode": "availableFixes:\n- name: \"Set the HttpOnly flag to true\"\n  actions:\n  - addMethodCall:\n      name: \"setHttpOnly\"\n      arguments:\n      - \"true\"\n      position: \"first-available-spot\"\n",
+        "ruleName": "Session configuration: Cookies: Configure HttpOnly flag",
+        "category": "improper_session_handling:improper_flags_in_cookie_headers",
+        "ruleID": "d34a476b-dede-44c7-8484-03ec48cc8661",
+        "disableRuleIDs": [],
+        "ruleDescriptionFile": "SessionconfigurationCookiesConfigureHttpOnlyflag.html",
+        "ruleShortDescription": "Prevent client-side scripts from accessing the cookie by setting the HttpOnly flag to true",
+        "ruleErrorLevel": 2,
+        "ruleScope": [],
+        "ruleEnabled": true
+      }
     }
   ],
   "generators": []

--- a/recipes/spring/spring-boot/descriptions/SessionconfigurationCookiesConfigureHttpOnlyflag.html
+++ b/recipes/spring/spring-boot/descriptions/SessionconfigurationCookiesConfigureHttpOnlyflag.html
@@ -1,0 +1,7 @@
+
+
+Session cookies are frequently the target of Cross-Site Scripting (XSS) attacks. The default setting of the HttpOnly flag is false, which is insecure. By setting the <code>setHttpOnly()</code> to true, the cookie cannot be accessed by client-side scripts.
+
+<table><tr><td><font color="gray">Before:</font></td><td><font color="#AA0000">Cookie cookie = new Cookie();</font></td></tr><tr><td><font color="gray">After:</font></td><td>Cookie cookie = new Cookie();
+        cookie.setHttpOnly(true);</td></tr></table>
+<h3>Resources</h3><ul><li><a href="https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#httponly-attribute">OWASP - Session Management Cheat Sheet - HttpOnly</a></li></ul>

--- a/recipes/spring/spring-boot/descriptions/SessionconfigurationCookiesConfigureSecureflag.html
+++ b/recipes/spring/spring-boot/descriptions/SessionconfigurationCookiesConfigureSecureflag.html
@@ -1,0 +1,7 @@
+
+
+Ensure the cookie is only sent over HTTPS by setting the <code>setSecure()</code> flag to true. Otherwise, when using the default setting, the cookie will be sent over an unencrypted HTTP connection and the session ID could be disclosed via a Man-in-the-Middle attack.
+
+<table><tr><td><font color="gray">Before:</font></td><td><font color="#AA0000">Cookie cookie = new Cookie();</font></td></tr><tr><td><font color="gray">After:</font></td><td>Cookie cookie = new Cookie();
+        cookie.setSecure(true);</td></tr></table>
+<h3>Resources</h3><ul><li><a href="https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#secure-attribute">OWASP - Session Management Cheat Sheet - Secure</a></li></ul>

--- a/recipes/spring/spring-boot/descriptions/SessionconfigurationCookiesSetHttpOnlyflagtotrue.html
+++ b/recipes/spring/spring-boot/descriptions/SessionconfigurationCookiesSetHttpOnlyflagtotrue.html
@@ -1,6 +1,6 @@
 
 
-Session cookies are frequently the target of Cross-Site Scripting (XSS) attacks. By setting the <code>setHttpOnly()</code> flag to true (which is also the default setting), the cookie cannot be accessed by client-side scripts.
+Session cookies are frequently the target of Cross-Site Scripting (XSS) attacks. By setting the <code>setHttpOnly()</code> flag to true, the cookie cannot be accessed by client-side scripts.
 
 <table><tr><td><font color="gray">Before:</font></td><td><font color="#AA0000">cookie.setHttpOnly(false);</font></td></tr><tr><td><font color="gray">After:</font></td><td>cookie.setHttpOnly(true);</td></tr></table>
 <h3>Resources</h3><ul><li><a href="https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#httponly-attribute">OWASP - Session Management Cheat Sheet - HttpOnly</a></li></ul>

--- a/recipes/spring/spring-boot/readme.md
+++ b/recipes/spring/spring-boot/readme.md
@@ -6,4 +6,6 @@ It covers the following protections:
 <ul>
 <li>Session configuration: Cookies: Set HttpOnly flag to true</li>
 <li>Session configuration: Cookies: Set Secure flag to true</li>
+<li>Session configuration: Cookies: Configure HttpOnly flag</li>
+<li>Session configuration: Cookies: Configure Secure flag</li>
 </ul>

--- a/recipes/spring/spring-boot/rules.sensei
+++ b/recipes/spring/spring-boot/rules.sensei
@@ -42,6 +42,40 @@
         "ruleScope": [],
         "ruleEnabled": true
       }
+    },
+    {
+      "type": "947034909c9b08d0b583170e594b0eb327933231",
+      "model": {
+        "yamlCode": "search:\n  instanceCreation:\n    not:\n      followedBy:\n        methodcall:\n          name: \"setSecure\"\n    type: \"org.springframework.boot.web.servlet.server.Session.Cookie\"\n",
+        "mver": 8,
+        "yamlQuickFixCode": "availableFixes:\n  - name: \"Set the Secure flag to true\"\n    actions:\n      - addMethodCall:\n          name: \"setSecure\"\n          arguments:\n            - \"true\"\n          position: \"first-available-spot\"\n",
+        "ruleName": "Session configuration: Cookies: Configure Secure flag",
+        "category": "improper_session_handling:improper_flags_in_cookie_headers",
+        "ruleID": "88411bb5-3cc5-4fb7-973e-2709792eaef8",
+        "disableRuleIDs": [],
+        "ruleDescriptionFile": "SessionconfigurationCookiesConfigureSecureflag.html",
+        "ruleShortDescription": "Prevent a cookie being sent over unencrypted HTTP by setting the Secure flag to true ",
+        "ruleErrorLevel": 2,
+        "ruleScope": [],
+        "ruleEnabled": true
+      }
+    },
+    {
+      "type": "947034909c9b08d0b583170e594b0eb327933231",
+      "model": {
+        "yamlCode": "search:\n  instanceCreation:\n    not:\n      followedBy:\n        methodcall:\n          name: \"setHttpOnly\"\n    type: \"org.springframework.boot.web.servlet.server.Session.Cookie\"\n",
+        "mver": 8,
+        "yamlQuickFixCode": "availableFixes:\n- name: \"Set the HttpOnly flag to true\"\n  actions:\n  - addMethodCall:\n      name: \"setHttpOnly\"\n      arguments:\n      - \"true\"\n      position: \"first-available-spot\"\n      target: \"self\"\n",
+        "ruleName": "Session configuration: Cookies: Configure HttpOnly flag",
+        "category": "improper_session_handling:improper_flags_in_cookie_headers",
+        "ruleID": "5a2c1b52-be7d-4ae3-bdff-5ddd35f40b64",
+        "disableRuleIDs": [],
+        "ruleDescriptionFile": "SessionconfigurationCookiesConfigureHttpOnlyflag.html",
+        "ruleShortDescription": "Prevent client-side scripts from accessing the cookie by setting the HttpOnly flag to true",
+        "ruleErrorLevel": 2,
+        "ruleScope": [],
+        "ruleEnabled": true
+      }
     }
   ],
   "generators": []

--- a/recipes/spring/spring-session/descriptions/SessionconfigurationCookiesConfigureSecureflag.html
+++ b/recipes/spring/spring-session/descriptions/SessionconfigurationCookiesConfigureSecureflag.html
@@ -1,0 +1,7 @@
+
+
+Ensure the cookie is only sent over HTTPS by setting the <code>setUseSecureCookie()</code> flag to true. Otherwise, when using the default setting, the cookie will be sent over an unencrypted HTTP connection and the session ID could be disclosed via a Man-in-the-Middle attack.
+
+<table><tr><td><font color="gray">Before:</font></td><td><font color="#AA0000">DefaultCookieSerializer defaultCookieSerializer = new DefaultCookieSerializer();</font></td></tr><tr><td><font color="gray">After:</font></td><td>DefaultCookieSerializer defaultCookieSerializer = new DefaultCookieSerializer();
+        defaultCookieSerializer.setUseSecureCookie(true);</td></tr></table>
+<h3>Resources</h3><ul><li><a href="https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#secure-attribute">OWASP - Session Management Cheat Sheet - Secure</a></li></ul>

--- a/recipes/spring/spring-session/readme.md
+++ b/recipes/spring/spring-session/readme.md
@@ -6,4 +6,5 @@ It covers the following protections:
 <ul>
 <li>Session configuration: Cookies: Set HttpOnly flag to true</li>
 <li>Session configuration: Cookies: Set Secure flag to true</li>
+<li>Session configuration: Cookies: Configure Secure flag</li>
 </ul>

--- a/recipes/spring/spring-session/rules.sensei
+++ b/recipes/spring/spring-session/rules.sensei
@@ -42,6 +42,23 @@
         "ruleScope": [],
         "ruleEnabled": true
       }
+    },
+    {
+      "type": "947034909c9b08d0b583170e594b0eb327933231",
+      "model": {
+        "yamlCode": "search:\n  instanceCreation:\n    not:\n      followedBy:\n        methodcall:\n          name: \"setUseSecureCookie\"\n    type: \"org.springframework.session.web.http.DefaultCookieSerializer\"\n",
+        "mver": 8,
+        "yamlQuickFixCode": "availableFixes:\n- name: \"Set Secure flag to true\"\n  actions:\n  - addMethodCall:\n      name: \"setUseSecureCookie\"\n      arguments:\n      - \"true\"\n      position: \"first-available-spot\"\n",
+        "ruleName": "Session configuration: Cookies: Configure Secure flag",
+        "category": "improper_session_handling:improper_flags_in_cookie_headers",
+        "ruleID": "bf43cb0e-25f4-42cd-940c-46e4076709cb",
+        "disableRuleIDs": [],
+        "ruleDescriptionFile": "SessionconfigurationCookiesConfigureSecureflag.html",
+        "ruleShortDescription": "Prevent a cookie being sent over unencrypted HTTP by setting the Secure flag to true",
+        "ruleErrorLevel": 2,
+        "ruleScope": [],
+        "ruleEnabled": true
+      }
     }
   ],
   "generators": []


### PR DESCRIPTION
Previous cookie recipes only checked for the existing methodcalls .setSecure(false) or .setHttponly(false). 

I checked for the default setting of these flags and created recipes that sets them to true in case they were false (and insecure) by default.